### PR TITLE
ModulesEnabled fixes

### DIFF
--- a/src/Audit/ModulesEnabled.php
+++ b/src/Audit/ModulesEnabled.php
@@ -49,7 +49,7 @@ class ModulesEnabled extends Audit implements RemediableInterface {
   public function remediate(Sandbox $sandbox) {
     $modules = $sandbox->getParameter('modules');
     $sandbox->drush()->en(implode(' ', $modules), '-y');
-    return $this->check($sandbox);
+    return $this->audit($sandbox);
   }
 
 }

--- a/src/Audit/ModulesEnabled.php
+++ b/src/Audit/ModulesEnabled.php
@@ -5,9 +5,15 @@ namespace Drutiny\Plugin\Drupal7\Audit;
 use Drutiny\Audit;
 use Drutiny\Sandbox\Sandbox;
 use Drutiny\RemediableInterface;
+use Drutiny\Annotation\Param;
 
 /**
  * Generic modules are enabled check.
+ * @Param(
+ *  name = "modules",
+ *  description = "List of modules to check that are enabled.",
+ *  type = "array",
+ * )
  */
 class ModulesEnabled extends Audit implements RemediableInterface {
 


### PR DESCRIPTION
Changing from `Sandbox::check()` to `Sandbox::audit()` in `ModulesEnabled::remediate()` fixes a PHP fatal; adding the `@Param` docblock to the class silences a warning. Both fixes allow me to use the `ModulesEnabled` policy in a d7 profile without noise.