### PR TITLE
Rename calls to check() to audit()

### DIFF
--- a/src/Audit/ModuleDisabled.php
+++ b/src/Audit/ModuleDisabled.php
@@ -46,7 +46,7 @@ class ModuleDisabled extends Audit implements RemediableInterface {
   public function remediate(Sandbox $sandbox) {
     $module = $sandbox->getParameter('module');
     $sandbox->drush()->dis($module, '-y');
-    return $this->check($sandbox);
+    return $this->audit($sandbox);
   }
 
 }

--- a/src/Audit/User1.php
+++ b/src/Audit/User1.php
@@ -77,7 +77,7 @@ class User1 extends Audit implements RemediableInterface {
       'email' => $sandbox->getParameter('email')
     ]);
 
-    return $this->check($sandbox);
+    return $this->audit($sandbox);
   }
 
 }


### PR DESCRIPTION
Accompanies change to Drutiny [Issue 217](https://www.github.com/drutiny/drutiny/issues/217).